### PR TITLE
docs: update CLAUDE.md to reflect Python post-processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Collects periodic snapshots of `/proc` filesystem files during benchmark executi
 
 ## Languages
 - Bash: collection scripts (`procstat-start`, `procstat-stop`, `procstat-collect`)
-- Perl: post-processor (`procstat-post-process`)
+- Python: post-processor (`procstat-post-process.py`)
 
 ## Key Files
 | File | Purpose |
@@ -13,7 +13,7 @@ Collects periodic snapshots of `/proc` filesystem files during benchmark executi
 | `procstat-start` | Validates collector, sets defaults, captures CPU topology, launches `procstat-collect` in background |
 | `procstat-collect` | Reads configured /proc files at intervals, appends timestamped snapshots |
 | `procstat-stop` | Kills collector, compresses output with xz |
-| `procstat-post-process` | Derives interrupt-rate metrics from snapshots using 4 parallel processes (uses `toolbox::metrics`, `toolbox::json` from `$TOOLBOX_HOME/perl`) |
+| `procstat-post-process.py` | Derives interrupt-rate metrics from snapshots using CDMMetrics |
 | `rickshaw.json` | Rickshaw integration: endpoint allow/block lists, file deployment, post-process script |
 | `workshop.json` | Engine image build requirements (minimal) |
 
@@ -24,4 +24,4 @@ Collects periodic snapshots of `/proc` filesystem files during benchmark executi
 ## Conventions
 - Primary branch is `master`
 - Runs as a profiler tool on master/worker/profiler roles, blocked on client/server
-- Standard Bash/Perl modelines and 4-space indentation
+- Standard Bash modelines and 4-space indentation


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect that post-processor is now Python, not Perl

🤖 Generated with [Claude Code](https://claude.com/claude-code)