### PR TITLE
Add softnet_stat collection and post-processing

### DIFF
--- a/procstat-post-process.py
+++ b/procstat-post-process.py
@@ -90,6 +90,72 @@ def process_interrupts(fork_idx, num_forks, log_file, cpu_topo):
     metrics.finish_samples()
 
 
+def process_softnet_stat(log_file, cpu_topo, file_id):
+    metrics = CDMMetrics()
+    curr_timestamp_ms = None
+    prev_timestamp_ms = None
+    prev_counts = {}
+
+    metric_names = {
+        0: "processed-sec",
+        1: "dropped-sec",
+        2: "time-squeeze-sec",
+    }
+
+    try:
+        fh, _ = open_read_text_file(log_file)
+    except FileNotFoundError:
+        print(f"ERROR: could not open {log_file}")
+        return
+
+    for line in fh:
+        line = line.rstrip("\n")
+
+        m = re.match(r'^DATE:(\d+\.\d+)$', line)
+        if m:
+            if curr_timestamp_ms is not None:
+                prev_timestamp_ms = curr_timestamp_ms
+            curr_timestamp_ms = int(float(m.group(1)) * 1000)
+            continue
+
+        fields = line.split()
+        if len(fields) < 13:
+            continue
+        try:
+            cpu = int(fields[12], 16)
+        except (ValueError, IndexError):
+            continue
+
+        for col_idx, metric_type in metric_names.items():
+            try:
+                curr_count = int(fields[col_idx], 16)
+            except (ValueError, IndexError):
+                continue
+
+            key = (cpu, col_idx)
+            if prev_timestamp_ms is not None and key in prev_counts:
+                time_diff_sec = (curr_timestamp_ms - prev_timestamp_ms) / 1000
+                if time_diff_sec > 0:
+                    rate = (curr_count - prev_counts[key]) / time_diff_sec
+                    package, die, core, thread = get_cpu_topology(cpu, cpu_topo)
+                    desc = {
+                        "class": "throughput",
+                        "source": "procstat",
+                        "type": metric_type,
+                    }
+                    names = {
+                        "package": package, "die": die, "core": core,
+                        "thread": thread, "num": cpu,
+                    }
+                    sample = {"value": rate, "end": curr_timestamp_ms}
+                    metrics.log_sample(file_id, desc, names, sample)
+
+            prev_counts[key] = curr_count
+
+    fh.close()
+    metrics.finish_samples()
+
+
 def main():
     num_forks = 4
     data_dir = "proc"
@@ -114,6 +180,15 @@ def main():
             for t in threads:
                 t.join()
             break
+
+    softnet_dir = os.path.join(data_dir, "net")
+    if os.path.isdir(softnet_dir):
+        for entry in sorted(os.listdir(softnet_dir)):
+            if entry.startswith("softnet_stat"):
+                log_file = os.path.join(softnet_dir, entry)
+                print(f"Processing softnet_stat from {log_file}")
+                process_softnet_stat(log_file, cpu_topo, "softnet")
+                break
 
     print("procstat post-processing complete")
 

--- a/procstat-start
+++ b/procstat-start
@@ -6,7 +6,7 @@ echo "args: $@"
 echo "pwd: `/bin/pwd`"
 echo "hostname: `hostname`"
 # defaults
-files="interrupts,vmstat,slabinfo,softirqs,meminfo,schedstat"
+files="interrupts,vmstat,slabinfo,softirqs,meminfo,schedstat,net/softnet_stat"
 interval=3
 procstat_collect="/usr/bin/procstat-collect"
 


### PR DESCRIPTION
## Summary

- Collect `/proc/net/softnet_stat` alongside existing `/proc` files to provide per-CPU packet processing rates
- Produces three new metric types:
  - `procstat::processed-sec` — packets processed per CPU per second
  - `procstat::dropped-sec` — packets dropped per CPU per second
  - `procstat::time-squeeze-sec` — NAPI budget exhaustion events per CPU per second
- Uses the same CPU topology breakouts (package, die, core, thread, num) as existing procstat metrics, enabling direct correlation with mpstat and interrupt data

## Motivation

During kernel IP forwarding performance testing, we needed visibility into per-CPU packet processing rates and NAPI budget exhaustion to diagnose scaling bottlenecks. mpstat shows CPU busy percentage but not how many packets each CPU processed. The softnet_stat counters fill this gap — they revealed that some CPUs processed 40% fewer packets than others despite receiving equal traffic per RX queue, leading to discovery of TX qdisc lock contention as the root cause.

## Changes

- `procstat-start`: add `net/softnet_stat` to the default files list
- `procstat-post-process.py`: add `process_softnet_stat()` function that parses the hex-formatted softnet_stat (one row per CPU, columns: processed, dropped, time_squeeze, ..., cpu_id at column 12) and computes per-second rates using `CDMMetrics`

## Test plan

- [x] Verified collection works — `proc/net/softnet_stat.xz` captured on remote hosts
- [x] Verified post-processing — `metric-data-softnet.csv.xz` and `.json.xz` generated
- [x] Verified querying — `crucible get metric --source procstat --type processed-sec --breakout hostname,num` returns per-CPU data
- [x] Verified data correctness — per-CPU processed-sec sums to total forwarded packets

🤖 Generated with [Claude Code](https://claude.com/claude-code)