### PR TITLE
fix: sleep in inner per-file loop, missing exit, and typos

### DIFF
--- a/procstat-collect
+++ b/procstat-collect
@@ -5,7 +5,7 @@ interval=$1; shift
 
 re='^[1-9][0-9]*$'
 if [[ ! "$interval" =~ $re ]]; then
-    echo "Interval must a be a positive interger, exiting"
+    echo "Interval must be a positive integer, exiting"
     exit 1
 fi
 
@@ -41,6 +41,6 @@ while [ 1 == 1 ]; do
         this_date="DATE:`date +%s.%N`"
         echo -e "\n$this_date" >>$local_file
         cat /proc/$file >>$local_file
-        sleep $interval
     done
+    sleep $interval
 done

--- a/procstat-start
+++ b/procstat-start
@@ -36,7 +36,7 @@ while true; do
             break
             ;;
         *)
-            echo "Invalid optioni: $1"
+            echo "Invalid option: $1"
             exit 1
     esac
 done
@@ -54,7 +54,7 @@ find /proc/irq -mindepth 1 -type f | while read line; do
     cat $line >proc-irq/$line
 done
 
-/bin/rm -f procstat-pids.txt
+/bin/rm -f procstat-pid.txt
 if [ -e $procstat_collect ]; then
     $procstat_collect $files $interval &
     procstat_pid=$!
@@ -66,4 +66,5 @@ if [ -e $procstat_collect ]; then
     echo $procstat_pid >procstat-pid.txt
 else
     echo "$procstat_collect is not present, exiting"
+    exit 1
 fi

--- a/procstat-stop
+++ b/procstat-stop
@@ -16,7 +16,7 @@ if [ -e procstat-pid.txt ]; then
         xz -3 -T 0 $line
     done
 else
-    echo "procstst-pid.txt not found"
+    echo "procstat-pid.txt not found"
     echo "PWD: `/bin/pwd`"
     echo "LS:"
     /bin/ls -l


### PR DESCRIPTION
## Summary

- **procstat-collect**: `sleep $interval` was inside the inner per-file loop instead of the outer while loop, multiplying the sample interval by the number of files being collected. With the default 7 files and 3-second interval, each iteration took 21 seconds instead of 3.
- **procstat-start**: missing `exit 1` when the procstat-collect binary is not present — exits 0 and silently masks the failure. Also fixes `rm` target mismatch (`procstat-pids.txt` vs actual `procstat-pid.txt`).
- **procstat-stop**: typo in error message (`procstst-pid.txt`).
- Minor typo fixes in error messages across all three scripts.

## Jira

- [PERFNFV-386](https://redhat.atlassian.net/browse/PERFNFV-386)

## Test plan

- [x] `bash -n` passes on all three scripts
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)